### PR TITLE
Make zapm-editor compatible with both new and old version of zpm

### DIFF
--- a/src/mac/_ZAPM/ed/_ZAPM.ed.a.mac
+++ b/src/mac/_ZAPM/ed/_ZAPM.ed.a.mac
@@ -33,13 +33,21 @@ nszpm  ;Navigator for namespace and zpm modules --------------------------------
  ;S $P(@BSR@(BST),"@",39)="^%ZAPM.ed.BSC,ZHELP1" //help text
  kill tab
  Set currentns=$Namespace
- Do ##class(%ZPM.PackageManager).GetListNamespace(.namespace)
+ If $System.CLS.IsMthd("%IPM.Main", "GetListNamespace") {
+ 	Do ##class(%IPM.Main).GetListNamespace(.namespace)
+ } Else {
+ 	Do ##class(%ZPM.PackageManager).GetListNamespace(.namespace)
+ }
   Set ns="",num=0
 	For { set ns=$Order(namespace(ns)) Quit:ns=""
 		Set $Namespace=ns
 		Kill list
 		set name=""
-		Do ##class(%ZPM.PackageManager).GetListModules("",.list)
+		If $System.CLS.IsMthd("%IPM.Main", "GetListModules") {
+			Do ##class(%IPM.Main).GetListModules("",.list)
+		} Else {
+			Do ##class(%ZPM.PackageManager).GetListModules("",.list)
+		}
 		If $D(list) {
 			Set module="",write=0
 			For { set module=$Order(list(module)) Quit:module=""


### PR DESCRIPTION
Hi @SergeyMi37 

## Background

InterSystems is planning to release a new version of IPM (previously known as ZPM). We made some breaking changes in this release, including renaming of packages and classes. Since your package references one or more of such renamed classes, we would like to help you update your package so that it's compatible with both new and old package managers.

## Testing

### Older Versions

You can test that this PR works on older versions (ZPM v0.7.1 and earlier) by running

```bash
zpm "load https://github.com/isc-shuliu/zapm-editor"
```

### Newer Versions

You can also test the PR on our unreleased new package manager by running it in a container

```bash
git clone https://github.com/intersystems/ipm
cd ipm
git checkout v1
docker compose up -d
docker exec -it ipm-sandbox-1 /bin/bash
```

Then, in the docker container, run `iris session IRIS` to enter iris shell
```
do $System.OBJ.Load("/home/irisowner/zpm/preload/cls/IPM/Installer.cls", "ck")
do ##class(IPM.Installer).setup("/home/irisowner/zpm/")
zpm "repo -delete-all"
zpm "repo -reset-defaults"
```

Also, since the newer version of IPM is installed on a per-namespace level, you may want to enable package mapping if your code touches other namespaces.

Finally, you can run 

```
zpm "load https://github.com/isc-shuliu/zapm-editor"
```

to verify successful installation. 



Let me know if you have any questions!